### PR TITLE
共通サイドバー③ログイン中に表示される、ログアウトアイコンの実装完了

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,11 @@
   </head>
 
   <body class="bg-pink-50">
+
+    <div class="fixed left-0 top-1/2 transform -translate-y-1/2 bg-transparent p-5">
+      <%= link_to "ログアウト", logout_path, data: { turbo_method: :delete } %>
+    </div>
+
     <main class="container mx-auto mt-28 px-5 flex">
       <%= render "layouts/flash_messages" %>
       <%= yield %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,9 +16,11 @@
   <body class="bg-pink-50">
 
     <div class="fixed left-0 top-1/2 transform -translate-y-1/2 bg-transparent p-5">
+    <% if logged_in? %>
       <%= link_to logout_path, data: { turbo_method: :delete } do %>
         <i class="fa-solid fa-arrow-right-from-bracket fa-lg hover:text-blue-500"></i>
       <% end %>
+    <% end %>
     </div>
 
     <main class="container mx-auto mt-28 px-5 flex">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,12 +10,15 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
     <%= favicon_link_tag "favicon.ico" %>
+    <script src="https://kit.fontawesome.com/2ad9886cff.js" crossorigin="anonymous"></script>
   </head>
 
   <body class="bg-pink-50">
 
     <div class="fixed left-0 top-1/2 transform -translate-y-1/2 bg-transparent p-5">
-      <%= link_to "ログアウト", logout_path, data: { turbo_method: :delete } %>
+      <%= link_to logout_path, data: { turbo_method: :delete } do %>
+        <i class="fa-solid fa-arrow-right-from-bracket fa-lg hover:text-blue-500"></i>
+      <% end %>
     </div>
 
     <main class="container mx-auto mt-28 px-5 flex">


### PR DESCRIPTION
## チケットへのリンク
<!-- #{issue番号} -->
close #48 
## やったこと
<!-- このプルリクで何をしたのか -->
ログイン中に表示されるログアウトアイコンをサイドバーに実装した。
## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）-->
なし
## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
どのページにいても、ログアウトがサイドバーからできるようになる
## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
なし
## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
ローカルでログイン中に当該機能が表示されることを確認した
ローカルでログアウト中に当該機能が表示されないことを確認した
## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
なし