### PR TITLE
共通サイドバー④短歌一覧ページへのボタンリンクの作成完了

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,8 +16,14 @@
   <body class="bg-pink-50">
 
     <div class="fixed left-0 top-1/2 transform -translate-y-1/2 bg-transparent p-5 flex flex-col space-y-4">
-      <%= link_to posts_path do %>
-        <i class="fa-solid fa-users fa-lg hover:text-blue-500"></i>
+      <% if current_page?(posts_path) %>
+        <%= link_to root_path do %>
+          <i class="fa-solid fa-house fa-lg hover:text-blue-500"></i>
+        <% end %>
+      <% else %>
+        <%= link_to posts_path do %>
+          <i class="fa-solid fa-users fa-lg hover:text-blue-500"></i>
+        <% end %>
       <% end %>
       <% if logged_in? %>
         <%= link_to logout_path, data: { turbo_method: :delete } do %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,12 +15,15 @@
 
   <body class="bg-pink-50">
 
-    <div class="fixed left-0 top-1/2 transform -translate-y-1/2 bg-transparent p-5">
-    <% if logged_in? %>
-      <%= link_to logout_path, data: { turbo_method: :delete } do %>
-        <i class="fa-solid fa-arrow-right-from-bracket fa-lg hover:text-blue-500"></i>
+    <div class="fixed left-0 top-1/2 transform -translate-y-1/2 bg-transparent p-5 flex flex-col space-y-4">
+      <%= link_to posts_path do %>
+        <i class="fa-solid fa-users fa-lg hover:text-blue-500"></i>
       <% end %>
-    <% end %>
+      <% if logged_in? %>
+        <%= link_to logout_path, data: { turbo_method: :delete } do %>
+          <i class="fa-solid fa-arrow-right-from-bracket fa-lg hover:text-blue-500"></i>
+        <% end %>
+      <% end %>
     </div>
 
     <main class="container mx-auto mt-28 px-5 flex">


### PR DESCRIPTION
## チケットへのリンク
<!-- #{issue番号} -->
close #58 
## やったこと
<!-- このプルリクで何をしたのか -->
- [x] サイドバーに一覧ページ用アイコンを設置
- [x] アイコンと一覧ページをリンクする
- [x] 一覧ページにいるときは、アイコンをトップページに遷移するアイコンに置き換える
## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）-->
なし
## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
サイドバーから、短歌一覧ページへ遷移できる
短歌一覧ページにいるときは、トップページへ遷移できる
## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
なし
## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
ローカルで動作確認
短歌一覧ページへサイドバーのアイコンから移動できることを確認した
短歌一覧ページにいるときは、短歌一覧ページに遷移するためのアイコンが、トップページに遷移するためのアイコンに置き換わっていることを確認した（トップページに遷移することも確認済み）
## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
fontawesomeに登録してアイコンを拝借した。