### PR TITLE
共通サイドバー②ログイン中に表示される、ユーザーアイコン機能の実装完了

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,6 +5,10 @@ class PostsController < ApplicationController
     @posts = Post.all
   end
 
+  def current_user_page
+    @current_user_posts = current_user.posts
+  end
+
   def new
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,6 +26,9 @@
         <% end %>
       <% end %>
       <% if logged_in? %>
+        <%= link_to current_user_page_posts_path do %>
+          <i class="fa-solid fa-user fa-lg hover:text-blue-500"></i>
+        <% end %>
         <%= link_to logout_path, data: { turbo_method: :delete } do %>
           <i class="fa-solid fa-arrow-right-from-bracket fa-lg hover:text-blue-500"></i>
         <% end %>

--- a/app/views/posts/_current_user_post.html.erb
+++ b/app/views/posts/_current_user_post.html.erb
@@ -1,0 +1,10 @@
+<div class="max-w-md mx-auto bg-white rounded-xl shadow-md overflow-hidden md:max-w-2xl m-3 mb-4">
+  <div class="flex items-center justify-center">
+    <div class="p-8">
+      <p class="block mt-1 text-lg leading-tight font-medium text-black" style="writing-mode: vertical-rl;"><%= post.content %></p>
+      <% if post.user %>
+        <p class="mt-2 text-gray-500" style="writing-mode: vertical-rl;"><%= post.user.name %></p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/posts/current_user_page.html.erb
+++ b/app/views/posts/current_user_page.html.erb
@@ -1,0 +1,3 @@
+<h1>My Posts</h1>
+
+<%= render @current_user_posts %>

--- a/app/views/posts/current_user_page.html.erb
+++ b/app/views/posts/current_user_page.html.erb
@@ -1,3 +1,5 @@
-<h1>My Posts</h1>
-
-<%= render @current_user_posts %>
+<% if @current_user_posts.blank? %>
+  <p>まだ投稿がありません。</p>
+<% else %>
+  <%= render @current_user_posts %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   resources :posts, only: %i[new] do
     post 'generate_tanka', on: :collection
     get 'generate_tanka', on: :collection
+    get 'current_user_page', on: :collection
   end
   resources :posts
 end


### PR DESCRIPTION
## チケットへのリンク
<!-- #{issue番号} -->
close #47 
## やったこと
<!-- このプルリクで何をしたのか -->
・ログイン中のユーザーの投稿だけをまとめたページを作成した
・上記ページへのリンクアイコンをサイドバーに設置した
## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）-->
なし
## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
自分が投稿した短歌がまとまったページが見れる
## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
なし
## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
ローカルで、ログイン中のユーザーの投稿だけが、ユーザーページに表示されていることを確認した
サイドバーから上記ページへ遷移できることを確認した
## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
なし