### PR TITLE
短歌一覧ページに動きを追加完了

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,86 @@
  *= require_tree .
  *= require_self
  */
+
+/* 短歌をホバーした時の回転 */
+.wrapper {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.card {
+  position: relative;
+  cursor: pointer;
+  width: 30%;
+  height: 330px;
+  padding: 1rem;
+  box-sizing: border-box;
+  transform-style: preserve-3d;
+  perspective: 1000px;
+}
+
+.card-front,
+.card-back {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  backface-visibility: hidden;
+  text-align: center;
+  transition: 0.5s;
+  box-shadow: 0 0 10px #555;
+}
+
+.card-front {
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+  filter: brightness(80%);
+  transform: rotateY(0deg);
+}
+
+.card-back {
+  padding: 2rem 1rem;
+  color: white;
+  box-sizing: border-box;
+  transform: rotateY(180deg);
+  background-color: #353535;
+}
+
+
+.card:hover .card-front {
+  transform: rotateY(-180deg);
+}
+
+.card:hover .card-back {
+  transform: rotateY(0deg);
+}
+
+
+.card-title {
+  padding: 0.5rem 1rem;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.card-description {
+  margin: 1rem 0 4rem;
+  line-height: 1.5;
+}
+
+.card-link {
+  padding: 1rem;
+  color: #fff;
+  text-decoration: none;
+  border: 2px solid #fff;
+  transition: all .5s;
+}
+
+.card-link:hover {
+  background-color: #fff;
+  color: #333;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -76,7 +76,7 @@
 .card-title {
   padding: 0.5rem 1rem;
   font-size: 1.5rem;
-  font-weight: bold;
+  /* font-weight: bold; */
 }
 
 .card-description {

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -61,6 +61,7 @@ class PostsController < ApplicationController
     @tankas = tanka_response.split("\n").reject(&:empty?)
 
     # セッションに保存
+    session[:title] = user_input
     session[:tankas] = @tankas
 
     render 'generate_tanka'
@@ -68,10 +69,14 @@ class PostsController < ApplicationController
 
   def create
     @post = Post.new(post_params)
+    # セッションからuser_inputを取得
+    @post.title = session[:title]
     # 現在のユーザーを@postの作成者として設定する
     @post.user = current_user
 
     if @post.save
+      # セッションからuser_inputを削除
+      session.delete(:title)
       redirect_to @post, notice: 'Post was successfully created.'
     else
       render 'new'
@@ -85,6 +90,6 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:content)
+    params.require(:post).permit(:content, :title)
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
       <% end %>
     </div>
 
-    <main class="container mx-auto mt-28 px-5 flex">
+    <main class="<%= 'container mx-auto mt-28 px-5 flex' unless controller_name == 'posts' && action_name == 'index' %>">
       <%= render "layouts/flash_messages" %>
       <%= yield %>
     </main>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,10 +1,12 @@
-<div class="max-w-md mx-auto bg-white rounded-xl shadow-md overflow-hidden md:max-w-2xl m-3 mb-4">
-  <div class="flex items-center justify-center">
-    <div class="p-8">
-      <p class="block mt-1 text-lg leading-tight font-medium text-black" style="writing-mode: vertical-rl;"><%= post.content %></p>
-      <% if post.user %>
-        <p class="mt-2 text-gray-500" style="writing-mode: vertical-rl;"><%= post.user.name %></p>
-      <% end %>
+<div class="wrapper max-w-md mx-auto">
+  <div class="card">
+    <div class="card-front flex items-center justify-center" style="writing-mode: vertical-rl;"><%= post.content %></div>
+    <div class="card-back">
+      <div class="card-description" style="writing-mode: vertical-rl;">
+        <p>テキストが入ります。テキストが入ります。テキストが入ります。</p>
+      </div>
+        <a href="#" class="card-link">詳細</a>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,9 +1,11 @@
 <div class="wrapper max-w-md mx-auto">
   <div class="card">
-    <div class="card-front flex items-center justify-center" style="writing-mode: vertical-rl;"><%= post.content %></div>
+    <div class="card-front flex items-center justify-center" style="writing-mode: vertical-rl;">
+      <%= post.content %>
+    </div>
     <div class="card-back">
       <div class="card-description" style="writing-mode: vertical-rl;">
-        <p>テキストが入ります。テキストが入ります。テキストが入ります。</p>
+        <%= post.title %>
       </div>
         <a href="#" class="card-link">詳細</a>
       </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,3 +1,1 @@
-<h1>All Posts</h1>
-
 <%= render @posts %>

--- a/db/migrate/20240502112953_add_title_to_posts.rb
+++ b/db/migrate/20240502112953_add_title_to_posts.rb
@@ -1,0 +1,5 @@
+class AddTitleToPosts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :posts, :title, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_28_152047) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_02_112953) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_28_152047) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.text "title"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 


### PR DESCRIPTION
## チケットへのリンク
<!-- #{issue番号} -->
close #44 
## やったこと
<!-- このプルリクで何をしたのか -->
短歌一覧ページに表示する短歌それぞれに、回転するアニメーションをCSSで付与した。
カードを捲るように動きをつけることで、裏面にもととなった文章を表示することを可能にした。
## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）-->
なし
## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
短歌を捲ることで、もととなった文章が見れる。
## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
なし
## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
ローカルで、以下を確認した。
・アニメーションが反映されていること
・短歌の裏側に、もととなった文章が表示されていること
## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
Postテーブルにtitleカラムを追加してあります。
参考
https://pa-tu.work/t/7148