### PR TITLE
短歌一覧ページのカードの後ろを、ログインの有無によって表示を変える①現在のユーザーが自分のカードをホバーした場合

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -87,6 +87,12 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
   end
 
+  def destroy
+    post = current_user.posts.find(params[:id])
+    post.destroy!
+    redirect_to posts_path, notice: '短歌を削除しました。', status: :see_other
+  end
+
   private
 
   def post_params

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -8,6 +8,9 @@
         <%= post.title %>
       </div>
         <a href="#" class="card-link">詳細</a>
+        <% if current_user == post.user %>
+          <%= link_to '削除', post_path(post), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' } %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -7,7 +7,7 @@
       <div class="card-description" style="writing-mode: vertical-rl;">
         <%= post.title %>
       </div>
-        <a href="#" class="card-link">詳細</a>
+      <%= link_to "Share on X", "https://twitter.com/intent/tweet?text=#{CGI.escape(post.content)}", class: "bg-pink-400 hover:bg-pink-600 text-white font-bold py-2 px-4 rounded mb-4 text-center", target: "_blank" %>
         <% if current_user == post.user %>
           <%= link_to '削除', post_path(post), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' } %>
         <% end %>


### PR DESCRIPTION
## チケットへのリンク
<!-- #{issue番号} -->
close #45 
## やったこと
<!-- このプルリクで何をしたのか -->
短歌をホバーした時の挙動
・現在ログイン中のユーザーが作成者と一致していた場合、削除ボタンを表示する
・ポストコントローラに削除のアクションを実装した
・短歌の裏面に、Xへシェアボタンを配置した
## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）-->
なし
## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
自分が作成した短歌を削除できるようになる
自分以外のユーザーが作成した短歌もXへシェアできるようになる
## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
なし
## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
・ログインユーザーと作成者が一致している時に削除ボタンが表示されることを確認した
・削除ボタンを押すと短歌が削除されることを確認した
・作成者に関わらず、Xへシェアボタンが表示されることを確認した
## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
なし