### PR TITLE
短歌にあった画像をAIが生成する機能の実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -83,9 +83,11 @@ class PostsController < ApplicationController
     # 現在のユーザーを@postの作成者として設定する
     @post.user = current_user
 
+    # プロンプトを作成
+    prompt = @post.title
     # 画像生成APIを利用して画像を生成
-    image_api = OpenAi::ImageApi.new(@post.title) 
-    image_url = image_api.generate_image
+    image_api = OpenAi::ImageApi.new
+    image_url = image_api.generate_image(prompt)
     # 生成した画像のURLを@postに保存
     @post.image_url = image_url
 
@@ -111,6 +113,6 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:content, :title)
+    params.require(:post).permit(:content, :title, :image_url)
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -83,6 +83,12 @@ class PostsController < ApplicationController
     # 現在のユーザーを@postの作成者として設定する
     @post.user = current_user
 
+    # 画像生成APIを利用して画像を生成
+    image_api = OpenAi::ImageApi.new(@post.title) 
+    image_url = image_api.generate_image
+    # 生成した画像のURLを@postに保存
+    @post.image_url = image_url
+
     if @post.save
       # セッションからuser_inputを削除
       session.delete(:title)

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -6,6 +6,8 @@
     <div class="font-serif text-lg mb-6", style="writing-mode: vertical-rl; text-orientation: upright;">
       <%= @post.content %>
     </div>
+    <div class="font-serif text-lg mb-6", style="writing-mode: vertical-rl; text-orientation: upright;">
+      <%= @post.image_url %>
   </div>
   <div class="flex flex-col">
     <%= link_to "Share on X", "https://twitter.com/intent/tweet?text=#{CGI.escape(@post.content)}", class: "bg-pink-400 hover:bg-pink-600 text-white font-bold py-2 px-4 rounded mb-4 text-center", target: "_blank" %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -7,7 +7,7 @@
       <%= @post.content %>
     </div>
     <div class="font-serif text-lg mb-6", style="writing-mode: vertical-rl; text-orientation: upright;">
-      <%= @post.image_url %>
+      <%= image_tag @post.image_url %>
   </div>
   <div class="flex flex-col">
     <%= link_to "Share on X", "https://twitter.com/intent/tweet?text=#{CGI.escape(@post.content)}", class: "bg-pink-400 hover:bg-pink-600 text-white font-bold py-2 px-4 rounded mb-4 text-center", target: "_blank" %>

--- a/db/migrate/20240515031643_add_image_url_to_posts.rb
+++ b/db/migrate/20240515031643_add_image_url_to_posts.rb
@@ -1,0 +1,5 @@
+class AddImageUrlToPosts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :posts, :image_url, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_02_112953) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_15_031643) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,6 +20,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_02_112953) do
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.text "title"
+    t.text "image_url"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 

--- a/lib/open_ai/image_api.rb
+++ b/lib/open_ai/image_api.rb
@@ -1,6 +1,6 @@
 class OpenAi::ImageApi
-  def initialize(api_key)
-    @api_key = api_key
+  def initialize
+    @api_key = ENV["OPEN_AI_API_KEY"]
     @base_url = 'https://api.openai.com/v1/images/generations'
   end
 
@@ -38,17 +38,17 @@ class OpenAi::ImageApi
 end
 
 # APIキーを設定
-api_key = ENV["OPEN_AI_API_KEY"]
+# api_key = ENV["OPEN_AI_API_KEY"]
 
 # インスタンス作成
-image_api = OpenAi::ImageApi.new(api_key)
+# image_api = OpenAi::ImageApi.new(api_key)
 
 # ユーザー入力を受け取り、画像を生成
-puts "Please enter a description for the image you want to generate:"
-user_input = gets.chomp
+# puts "Please enter a description for the image you want to generate:"
+# user_input = gets.chomp
 
 # 画像生成
-image_url = image_api.generate_image(user_input)
+# image_url = image_api.generate_image(user_input)
 
 # 画像URLを表示
-puts "Image generated! You can view it at: #{image_url}"
+# puts "Image generated! You can view it at: #{image_url}"

--- a/lib/open_ai/image_api.rb
+++ b/lib/open_ai/image_api.rb
@@ -1,0 +1,54 @@
+class OpenAi::ImageApi
+  def initialize(api_key)
+    @api_key = api_key
+    @base_url = 'https://api.openai.com/v1/images/generations'
+  end
+
+  def get_api_headers
+    {
+      "Authorization" => "Bearer #{@api_key}",
+      "Content-Type" => "application/json"
+    }
+  end
+
+  def generate_image(prompt)
+    conn = Faraday.new(url: @base_url) do |faraday|
+      faraday.request :json
+      faraday.response :json, content_type: /\bjson$/
+      faraday.adapter Faraday.default_adapter
+    end
+
+    payload = {
+      prompt: prompt,
+      model: "dall-e-3",
+      n: 1,
+      size: "1024x1024"
+    }
+
+    response = conn.post do |req|
+      req.headers = get_api_headers
+      req.body = payload.to_json
+    end
+
+    response_body = response.body
+    image_url = response_body['data'][0]['url']
+
+    image_url
+  end
+end
+
+# APIキーを設定
+api_key = ENV["OPEN_AI_API_KEY"]
+
+# インスタンス作成
+image_api = OpenAi::ImageApi.new(api_key)
+
+# ユーザー入力を受け取り、画像を生成
+puts "Please enter a description for the image you want to generate:"
+user_input = gets.chomp
+
+# 画像生成
+image_url = image_api.generate_image(user_input)
+
+# 画像URLを表示
+puts "Image generated! You can view it at: #{image_url}"


### PR DESCRIPTION
## チケットへのリンク
<!-- #{issue番号} -->
close #117 
## やったこと
<!-- このプルリクで何をしたのか -->
短歌にあった画像をAIが生成する機能の実装
## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）-->
・詳細ページのレイアウト調整
・生成された画像を再閲覧するページへアクセスできない（リンクがないため）事象の解消
（解消手段：投稿一覧ページもしくはそれに準ずるページに画像を配置する）
全体的なレイアウトを決める時に、まとめて決める予定。
## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
選択した短歌にあった画像を生成することができる
## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
なし
## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
ローカルで画像が生成されることを確認した
## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
DBへ画像のパスを保存しているが、適切な保存方法なのか疑問が残る。