### PR TITLE
投稿一覧ページから詳細ページへのリンクを設置

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -15,7 +15,7 @@
           <%= post.title %>
         </div>
         <div class="flex items-center justify-center">
-          <%= link_to "Share X", "https://twitter.com/intent/tweet?text=#{CGI.escape(post.content)}", class: "bg-pink-400 hover:bg-pink-600 text-white font-bold py-2 px-4 rounded mb-4 text-center", target: "_blank" %>
+          <%= link_to '詳細', post, class: "bg-pink-400 hover:bg-pink-600 text-white font-bold py-2 px-4 rounded mb-4 text-center" %>
         </div>
       </div>
     </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,16 +1,19 @@
 <div class="flex flex-col items-center justify-center mx-auto">
   <div class="flex">
+    <% if @post.image_url.present? %>
+      <div class="font-serif text-lg mb-6", style="writing-mode: vertical-rl; text-orientation: upright;">
+        <%= image_tag @post.image_url %>
+      </div>
+    <% end %>
     <div class="font-serif text-lg mb-6", style="writing-mode: vertical-rl; text-orientation: upright;">
       <%= @post.user.name %>
     </div>
     <div class="font-serif text-lg mb-6", style="writing-mode: vertical-rl; text-orientation: upright;">
       <%= @post.content %>
     </div>
-    <div class="font-serif text-lg mb-6", style="writing-mode: vertical-rl; text-orientation: upright;">
-      <%= image_tag @post.image_url %>
   </div>
   <div class="flex flex-col">
     <%= link_to "Share on X", "https://twitter.com/intent/tweet?text=#{CGI.escape(@post.content)}", class: "bg-pink-400 hover:bg-pink-600 text-white font-bold py-2 px-4 rounded mb-4 text-center", target: "_blank" %>
-    <%= link_to 'トップページへ戻る', root_path, class: "bg-sky-400 hover:bg-sky-600 text-white font-bold py-2 px-4 rounded text-center" %>
+    <%= link_to '戻る', posts_path, class: "bg-sky-400 hover:bg-sky-600 text-white font-bold py-2 px-4 rounded text-center" %>
   </div>
 </div>


### PR DESCRIPTION
## チケットへのリンク
<!-- #{issue番号} -->
close #119 
## やったこと
<!-- このプルリクで何をしたのか -->
・投稿一覧ページの各投稿の裏側から、詳細ページへ遷移するためのリンクボタンを設置
・投稿一覧ページの各投稿の裏側から、Xへシェアボタンを削除
・画像を持たない投稿でも、詳細ページが正常に表示されるように修正
## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）-->
なし
## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
投稿一覧ページから、各投稿への詳細ページへ遷移できるようになる。
## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
なし
## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
・リンクボタンから詳細ページへ遷移することを確認
・Xへシェアボタンが削除されたことを確認
・画像を持たない投稿の詳細ページでも、正常に表示されることを確認
## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
なし