### PR TITLE
【不具合解消】生成した画像が読み込めない

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,3 +78,5 @@ gem "dotenv-rails", "~> 3.1"
 gem "ransack", "~> 4.1"
 
 gem "meta-tags", "~> 2.21"
+
+gem "aws-sdk-s3", "~> 1.151"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,22 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.929.0)
+    aws-sdk-core (3.196.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.8)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.81.0)
+      aws-sdk-core (~> 3, >= 3.193.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.151.0)
+      aws-sdk-core (~> 3, >= 3.194.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.8)
+    aws-sigv4 (1.8.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
     bigdecimal (3.1.7)
@@ -126,6 +142,7 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jmespath (1.6.2)
     jwt (2.8.1)
       base64
     loofah (2.22.0)
@@ -305,6 +322,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  aws-sdk-s3 (~> 1.151)
   bootsnap
   capybara
   debug

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -87,9 +87,9 @@ class PostsController < ApplicationController
     prompt = @post.title
     # 画像生成APIを利用して画像を生成
     image_api = OpenAi::ImageApi.new
-    image_url = image_api.generate_image(prompt)
+    s3_image_url = image_api.generate_and_upload_image_to_s3(prompt)
     # 生成した画像のURLを@postに保存
-    @post.image_url = image_url
+    @post.image_url = s3_image_url
 
     if @post.save
       # セッションからuser_inputを削除

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -113,6 +113,6 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:content, :title, :image_url)
+    params.require(:post).permit(:content, :title)
   end
 end

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,0 +1,4 @@
+Aws.config.update({
+  region: ENV['AWS_REGION'],
+  credentials: Aws::Credentials.new(ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY'])
+})

--- a/lib/open_ai/image_api.rb
+++ b/lib/open_ai/image_api.rb
@@ -36,19 +36,3 @@ class OpenAi::ImageApi
     image_url
   end
 end
-
-# APIキーを設定
-# api_key = ENV["OPEN_AI_API_KEY"]
-
-# インスタンス作成
-# image_api = OpenAi::ImageApi.new(api_key)
-
-# ユーザー入力を受け取り、画像を生成
-# puts "Please enter a description for the image you want to generate:"
-# user_input = gets.chomp
-
-# 画像生成
-# image_url = image_api.generate_image(user_input)
-
-# 画像URLを表示
-# puts "Image generated! You can view it at: #{image_url}"

--- a/lib/open_ai/image_api.rb
+++ b/lib/open_ai/image_api.rb
@@ -44,8 +44,12 @@ class OpenAi::ImageApi
     file_name = "generated_image_#{Time.now.to_i}.png"
     obj = s3.bucket(bucket_name).object("uploads/#{file_name}")
 
+    # Faradayを使用して画像をダウンロード
+    response = Faraday.get(image_url)
+    image_data = response.body
+
     # S3へ画像をアップロード
-    obj.put(body: URI.open(image_url), acl: 'public-read')
+    obj.put(body: image_data, acl: 'public-read')
 
     # アップロードした画像のURLを返す
     obj.public_url

--- a/lib/open_ai/image_api.rb
+++ b/lib/open_ai/image_api.rb
@@ -49,7 +49,7 @@ class OpenAi::ImageApi
     image_data = response.body
 
     # S3へ画像をアップロード
-    obj.put(body: image_data, acl: 'public-read')
+    obj.put(body: image_data)
 
     # アップロードした画像のURLを返す
     obj.public_url


### PR DESCRIPTION
## チケットへのリンク
<!-- #{issue番号} -->
close #123 
## やったこと
<!-- このプルリクで何をしたのか -->
サービス内で作成した画像の保存先をS3に変更した
S3に保存した画像をサービス内で表示されるようにした
## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）-->
なし
## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
画像が制限時間なしで見れるようになる
## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
なし
## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
ローカル環境で、画像を表示できていることを確認した
## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
環境変数はRender.comに設定済み。
本番環境での動作確認はこれからします。