### PR TITLE
【修正】ログインフォーム失敗時にメールアドレスの値を保持したい

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -16,9 +16,6 @@ class UserSessionsController < ApplicationController
     redirect_to root_path, status: :see_other, notice: 'ログアウトしました'
   end
 
-  def first_login_page
-  end
-
   def guest_login
     # 短歌作成者を表示するため使う可能性があるのでインスタンス変数に代入しておく
     @guest_user = User.create(

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -5,6 +5,7 @@ class UserSessionsController < ApplicationController
     if @user
       redirect_back_or_to root_path, notice: 'ログインに成功しました'
     else
+      @user = User.new(email: params[:email])
       flash.now[:alert] = 'ログインに失敗しました'
       render :new, status: :unprocessable_entity
     end

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -5,7 +5,7 @@
       <!-- Left column -->
       <div class="border p-4 rounded-lg shadow-md">
         <h2 class="text-lg text-white font-bold mb-4 underline text-center">会員登録がお済みの方</h2>
-        <%= form_with url: login_path, method: :post, class: "space-y-4" do |f| %>
+        <%= form_with model: @user, url: login_path, method: :post, class: "space-y-4" do |f| %>
           <div>
             <%= f.label :email, "メールアドレス", class: "block text-white" %>
             <%= f.email_field :email, class: "w-full px-3 py-2 border rounded-lg", required: true %>


### PR DESCRIPTION
## チケットへのリンク
<!-- #{issue番号} -->
#180 
## やったこと
<!-- このプルリクで何をしたのか -->
1回目のログイン失敗では、メールアドレスが保持される。
2回目のログイン失敗では、保持されない。
## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）-->
なし
## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
ログインに失敗しても、メールアドレスの打ち直しの手間が減るのでUXが向上する。
## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
なし
## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
テスト実施済み。
1度目の失敗ではメールアドレスが保持。
2度目の失敗ではメールアドレスが消えることを確認。
## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
本当は何回失敗してもメールアドレスの値は保持しておきたい。
おそらく、1回目と2回目で送信するパラメータの値に食い違いがあるから消えるのだと思われる。
```
00:48:21 web.1  |
00:48:26 web.1  | Started POST "/login" for ::1 at 2024-05-26 00:48:26 +0900
00:48:26 web.1  | Processing by UserSessionsController#create as TURBO_STREAM
00:48:26 web.1  |   Parameters: {"authenticity_token"=>"[FILTERED]", "email"=>"aaa@aaa", "password"=>"[FILTERED]", "commit"=>"ログイン"}
00:48:26 web.1  |   User Load (3.5ms)  SELECT "users".* FROM "users" WHERE "users"."email" = 'aaa@aaa' ORDER BY "users"."id" ASC LIMIT $1  [["LIMIT", 1]]
00:48:26 web.1  |   ↳ app/controllers/user_sessions_controller.rb:3:in `create'
00:48:27 web.1  |   Rendering layout layouts/application.html.erb
00:48:27 web.1  |   Rendering user_sessions/new.html.erb within layouts/application
00:48:27 web.1  |   Rendered user_sessions/new.html.erb within layouts/application (Duration: 1.2ms | Allocations: 393)
00:48:27 web.1  |   Rendered layouts/_flash_messages.html.erb (Duration: 0.0ms | Allocations: 14)
00:48:27 web.1  |   Rendered layout layouts/application.html.erb (Duration: 8.4ms | Allocations: 10338)
00:48:27 web.1  | Completed 422 Unprocessable Entity in 267ms (Views: 9.3ms | ActiveRecord: 42.4ms | Allocations: 19177)
00:48:27 web.1  |
00:48:27 web.1  |
00:48:39 web.1  | Started POST "/login" for ::1 at 2024-05-26 00:48:39 +0900
00:48:39 web.1  | Processing by UserSessionsController#create as TURBO_STREAM
00:48:39 web.1  |   Parameters: {"authenticity_token"=>"[FILTERED]", "user"=>{"email"=>"aaa@aaa", "password"=>"[FILTERED]"}, "commit"=>"ログイン"}
00:48:39 web.1  |   Rendering layout layouts/application.html.erb
00:48:39 web.1  |   Rendering user_sessions/new.html.erb within layouts/application
00:48:39 web.1  |   Rendered user_sessions/new.html.erb within layouts/application (Duration: 1.5ms | Allocations: 376)
00:48:39 web.1  |   Rendered layouts/_flash_messages.html.erb (Duration: 0.1ms | Allocations: 14)
00:48:39 web.1  |   Rendered layout layouts/application.html.erb (Duration: 13.7ms | Allocations: 10260)
00:48:39 web.1  | Completed 422 Unprocessable Entity in 17ms (Views: 14.4ms | ActiveRecord: 0.0ms | Allocations: 10851)
00:48:39 web.1  |
00:48:39 web.1  |
```
