### PR TITLE
フォントを行書体風に変更する試み

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -137,8 +137,7 @@
     <style>
       body {
         overflow-x: hidden;
-        font-family: "Hiragino Gyosyo W4 JIS2004";
-        font-family: "ヒラギノ行書 W4 JIS2004";
+        font-family: "Hiragino Gyosyo W8 JIS2004";
       }
       .hamburger {
         width: 40px;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,6 @@
     <%= favicon_link_tag "favicon.ico" %>
     <script src="https://kit.fontawesome.com/2ad9886cff.js" crossorigin="anonymous"></script>
     <%= display_meta_tags(default_meta_tags) %>
-
     <video autoplay muted loop class="fixed top-0 left-0 w-full h-full z-[-1] object-cover">
       <source src="/videos/22451_1280x720 (1).mp4" type="video/mp4">
     </video>
@@ -74,9 +73,10 @@
         z-index: 0;
       }
     </style>
+    <script type="text/javascript" src="//typesquare.com/3/tsst/script/ja/typesquare.js?6652a18c3fbc452583064c4dac1e02e5" charset="utf-8"></script>
   </head>
 
-  <body class="font-serif flex flex-col min-h-screen">
+  <body class="flex flex-col min-h-screen">
   
     <% if first_visit %>
       <% if current_page?(root_path) %>
@@ -137,6 +137,8 @@
     <style>
       body {
         overflow-x: hidden;
+        font-family: "Hiragino Gyosyo W4 JIS2004";
+        font-family: "ヒラギノ行書 W4 JIS2004";
       }
       .hamburger {
         width: 40px;


### PR DESCRIPTION
## チケットへのリンク
<!-- #{issue番号} -->
close #182 
## やったこと
<!-- このプルリクで何をしたのか -->
WEBアプリ全体のフォントを行書体に変更。
理由：行書体の方が短歌の世界観が反映されると思ったから。
採用したフォント：
ヒラギノ行書 W8 JIS2004
https://typesquare.com/fontlist/ajaxSearch/page:3
注意：
無料プランでは１フォント１サイトまでの使用制限あり。
そのため、ローカルホストと独自ドメインの利用を両立することはできない。
プルリクマージ後、typesquare設定ページから、ドメインの登録を変更する必要あり。
## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）-->
なし
## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
短歌の世界観をより感じることができる。
## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
なし
## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
フォントの反映を確認済み。
## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
なし