### PR TITLE
【修正】短歌選択画面で、短歌の外側をホバーすると短歌内が全て白くなってしまう現象を修正する

### DIFF
--- a/app/views/posts/select.html.erb
+++ b/app/views/posts/select.html.erb
@@ -30,6 +30,37 @@
     text-orientation: upright;
     white-space: nowrap;
   }
+
+  .option:hover .vertical-text {
+    color: black;
+  }
+
+  .loader {
+    border-top-color: #3490dc;
+    animation: spinner 1.5s linear infinite;
+  }
+
+  @keyframes spinner {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+
+  .option:hover,
+  .selected:hover {
+    background-color: white;
+  }
+
+  .selected {
+    background-color: white;
+  }
+
+  .selected .vertical-text {
+    color: black;
+  }
 </style>
 
 <!-- モーダルウィンドウ -->
@@ -45,37 +76,6 @@
     <p class="text-sm text-gray-700">現在も日本文学の重要な一部として続いています。</p>
   </div>
 </div>
-
-<style>
-  .loader {
-    border-top-color: #3490dc;
-    animation: spinner 1.5s linear infinite;
-  }
-
-  @keyframes spinner {
-    0% {
-      transform: rotate(0deg);
-    }
-    100% {
-      transform: rotate(360deg);
-    }
-  }
-</style>
-
-<style>
-  .option:hover,
-  .selected:hover {
-    background-color: white;
-  }
-
-  .selected {
-    background-color: white;
-  }
-
-  .selected .vertical-text {
-    color: black;
-  }
-</style>
 
 <script>
   document.addEventListener('DOMContentLoaded', (event) => {


### PR DESCRIPTION
## チケットへのリンク
<!-- #{issue番号} -->
close #184 
## やったこと
<!-- このプルリクで何をしたのか -->
生成した短歌の選択肢について。
ホバーした時、短歌内の要素が複数ある。
一番外側の要素をホバーした時に、短歌の中の文字が消える（正確にはテキストカラーが背景と同化して見えなくなる）現象を確認していた。
外側の要素をホバーした段階で、子要素のテキストの色を変更することで対応した。
## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）-->
なし
## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
UXが向上する。
## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
なし
## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
テストエラーなし。
変更が反映されていることを確認した。
## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
なし