### PR TITLE
AIが生成した画像の形式を変更することで画像の表示を軽くする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,3 +83,5 @@ gem "ransack", "~> 4.1"
 gem "meta-tags", "~> 2.21"
 
 gem "aws-sdk-s3", "~> 1.151"
+
+gem "mini_magick", "~> 4.12"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,7 @@ GEM
     matrix (0.4.2)
     meta-tags (2.21.0)
       actionpack (>= 6.0.0, < 7.2)
+    mini_magick (4.12.0)
     mini_mime (1.1.5)
     minitest (5.22.3)
     msgpack (1.7.2)
@@ -357,6 +358,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   meta-tags (~> 2.21)
+  mini_magick (~> 4.12)
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.2)

--- a/lib/open_ai/image_api.rb
+++ b/lib/open_ai/image_api.rb
@@ -41,15 +41,31 @@ class OpenAi::ImageApi
   def upload_image_to_s3(image_url)
     s3 = Aws::S3::Resource.new
     bucket_name = ENV["S3_BUCKET_NAME"]
-    file_name = "generated_image_#{Time.now.to_i}.png"
+    # file名を.pngから.webpに変更
+    file_name = "generated_image_#{Time.now.to_i}.webp"
     obj = s3.bucket(bucket_name).object("uploads/#{file_name}")
 
     # Faradayを使用して画像をダウンロード
     response = Faraday.get(image_url)
     image_data = response.body
 
+    # 画像を一時ファイルに保存
+    temp_file = Tempfile.new(['temp_image', '.png'])
+    temp_file.binmode
+    temp_file.write(image_data)
+    temp_file.close
+
+    # 画像をwebp形式に変換
+    image = MiniMagick::Image.open(temp_file.path)
+    webp_image_path = temp_file.path.gsub('.png', '.webp')
+    image.format "webp"
+    image.write webp_image_path
+
     # S3へ画像をアップロード
-    obj.put(body: image_data)
+    obj.upload_file(webp_image_path)
+
+    # 一時ファイルを削除
+    temp_file.unlink
 
     # アップロードした画像のURLを返す
     obj.public_url


### PR DESCRIPTION
## チケットへのリンク
<!-- #{issue番号} -->
close #189 
## やったこと
<!-- このプルリクで何をしたのか -->
短歌に合わせた画像を生成したとき、画像の形式を.pngから.webpに変更することで、Webページの軽量化を試みた。
## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）-->
なし
## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
Webページが早く読み込まれることでUXが向上する。
## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
なし
## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
S3にwebpで保存されていることを確認した。
[![Image from Gyazo](https://i.gyazo.com/8cb31d2e95978f28e3edc59bc5828753.png)](https://gyazo.com/8cb31d2e95978f28e3edc59bc5828753)
## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
現在生成済みの画像も変換する必要があります。