### PR TITLE
S3に保存している.pngファイルを.webpに変換する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@
 /app/assets/builds/*
 !/app/assets/builds/.keep
 .DS_Store
+
+backup.sql

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@
 .DS_Store
 
 backup.sql
+backup_production.sql

--- a/db/migrate/20240528034447_update_image_url_to_webp.rb
+++ b/db/migrate/20240528034447_update_image_url_to_webp.rb
@@ -1,0 +1,13 @@
+class UpdateImageUrlToWebp < ActiveRecord::Migration[7.1]
+  def up
+    Post.where("image_url LIKE ?", "%.png").find_each do |post|
+      post.update(image_url: post.image_url.gsub(".png", ".webp"))
+    end
+  end
+
+  def down
+    Post.where("image_url LIKE ?", "%.webp").find_each do |post|
+      post.update(image_url: post.image_url.gsub(".webp", ".png"))
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_15_031643) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_28_034447) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/lib/tasks/image_converter.rb
+++ b/lib/tasks/image_converter.rb
@@ -1,0 +1,83 @@
+require 'aws-sdk-s3'
+require 'mini_magick'
+
+class ImageConverter
+  def initialize
+    @s3 = Aws::S3::Client.new(
+      access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+      region: ENV['AWS_REGION']
+    )
+    @bucket = ENV['S3_BUCKET_NAME']
+  end
+
+  def convert_all_png_to_webp
+    png_objects = list_png_objects
+    png_objects.each do |object|
+      convert_and_upload_image(object)
+    end
+  end
+
+  private
+
+  def list_png_objects
+    objects = []
+    continuation_token = nil
+
+    loop do
+      response = @s3.list_objects_v2(
+        bucket: @bucket,
+        prefix: 'uploads/',
+        continuation_token: continuation_token
+      )
+
+      objects += response.contents.select { |obj| obj.key.end_with?('.png') }
+      break unless response.is_truncated
+
+      continuation_token = response.next_continuation_token
+    end
+
+    objects
+  end
+
+  def convert_and_upload_image(object)
+    temp_file = download_image(object.key)
+    webp_file = convert_to_webp(temp_file)
+    upload_image_to_s3(webp_file, object.key)
+    cleanup_temp_files(temp_file, webp_file)
+  end
+
+  def download_image(key)
+    temp_file = Tempfile.new(['image', '.png'])
+    @s3.get_object({ bucket: @bucket, key: key }, target: temp_file.path)
+    temp_file
+  end
+
+  def convert_to_webp(temp_file)
+    image = MiniMagick::Image.open(temp_file.path)
+    webp_file = Tempfile.new(['image', 'webp'])
+    image.format 'webp' 
+    image.write(webp_file.path)
+    webp_file
+  end
+
+  def upload_image_to_s3(webp_file, original_key)
+    webp_key = original_key.gsub('.png', '.webp')
+    @s3.put_object(
+      bucket: @bucket,
+      key: webp_key,
+      body: File.open(webp_file.path),
+      # acl: 'public-read',
+    )
+  end
+
+  def cleanup_temp_files(*files)
+    files.each { |file| file.close! }
+  end
+end
+
+if __FILE__ == $0
+  converter = ImageConverter.new
+  converter.convert_all_png_to_webp
+end
+


### PR DESCRIPTION
## チケットへのリンク
<!-- #{issue番号} -->
#192 
## やったこと
<!-- このプルリクで何をしたのか -->
- [x] S3に保存済みの.pngを.webpに変換
- [x] ローカルDBに保存済みのS3への画像のpathの拡張子を.pngから.webpに変更
- [x] 本番DBに保存済みのS3への画像のpathの拡張子を.pngから.webpに変更するための設定を完了（デプロイ後、反映を確認予定）

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）-->
なし
## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
画像が.webpで読み込まれるようになるため、ページ表示速度が向上。ひいてはUXが向上する。
## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
なし
## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
テストok
開発環境のDBの.pngが.webpに変更されたことを確認した。
詳細は #192 コメントへ
## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
・本番環境でDBが更新されていることを、独自ドメインでアクセスしたのち検証ツールで画像の拡張子を確認することで確認予定です。
・DBバックアップは開発・本番環境ともに取得済みです。