### PR TITLE
行書体フォントを、短歌の部分にのみ適用する

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -85,7 +85,7 @@
     <script type="text/javascript" src="//typesquare.com/3/tsst/script/ja/typesquare.js?6652a18c3fbc452583064c4dac1e02e5" charset="utf-8"></script>
   </head>
 
-  <body class="flex flex-col min-h-screen">
+  <body class="font-serif flex flex-col min-h-screen">
   
     <% if first_visit %>
       <% if current_page?(root_path) %>
@@ -146,6 +146,9 @@
     <style>
       body {
         overflow-x: hidden;
+        # font-family: "Hiragino Gyosyo W8 JIS2004";
+      }
+      .gyosyo {
         font-family: "Hiragino Gyosyo W8 JIS2004";
       }
       .hamburger {

--- a/app/views/mypages/index.html.erb
+++ b/app/views/mypages/index.html.erb
@@ -15,7 +15,7 @@
           </div>
         <% end %>
         <div class="flex flex-col justify-between items-center space-y-4 flex-grow w-full">
-          <div class="font-bold text-4xl mb-6 text-center vertical-text flex-grow">
+          <div class="gyosyo font-bold text-4xl mb-6 text-center vertical-text flex-grow">
             <% post.content.split(/\s|　/).each do |line| %>
               <p><%= line %></p>
             <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -15,7 +15,7 @@
           </div>
         <% end %>
         <div class="flex flex-col justify-between items-center space-y-4 flex-grow w-full">
-          <div class="font-bold text-4xl mb-6 text-center vertical-text flex-grow">
+          <div class="gyosyo font-bold text-4xl mb-6 text-center vertical-text flex-grow">
             <% post.content.split(/\s|　/).each do |line| %>
               <p><%= line %></p>
             <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -10,7 +10,7 @@
       </div>
     <% end %>
     <div class="flex flex-col justify-center items-center space-y-4">
-      <div class="font-bold text-4xl mb-6 text-center vertical-text">
+      <div class="gyosyo font-bold text-4xl mb-6 text-center vertical-text">
         <% @post.content.split(/\s|　/).each do |line| %>
           <p><%= line %></p>
         <% end %>


### PR DESCRIPTION
## チケットへのリンク
<!-- #{issue番号} -->
#194 
## やったこと
<!-- このプルリクで何をしたのか -->
- [x] 短歌部分のみ行書体フォントが適用されるように変更
## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）-->
本番環境での確認。
１ドメインに１フォントの制限があるため、デプロイ後に確認予定。
## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
短歌部分だけ行書体になることで、メリハリが出る。それによって世界観により没入できる。
## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
なし
## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
ローカルで、行書体フォントを適用した部分は、bodyに適用している共通のフォントではなく、デフォルトのフォントになることを確認した。
## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
なし