### PR TITLE
OPENAIAPIタイムアウトエラーの原因特定と修正

### DIFF
--- a/lib/open_ai/image_api.rb
+++ b/lib/open_ai/image_api.rb
@@ -17,6 +17,10 @@ class OpenAi::ImageApi
       faraday.request :json
       faraday.response :json, content_type: /\bjson$/
       faraday.adapter Faraday.default_adapter
+      # 接続タイムアウトを設定 
+      faraday.options.open_timeout = 15
+      # 読み込みタイムアウトを設定
+      faraday.options.timeout = 60
     end
 
     payload = {


### PR DESCRIPTION
## チケットへのリンク
<!-- #{issue番号} -->
close #207 
## やったこと
<!-- このプルリクで何をしたのか -->
OPENAIAPIタイムアウトエラーの原因特定と修正
## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）-->
回線が重い環境での実テスト
## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
回線が重い環境でも画像の生成に成功する
## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
なし
## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
ローカル環境で画像が生成されることは確認
## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
重い環境での生成をテストはしていない（ユーザーの環境がどれくらい重いかはユーザー環境に依存するため）
上限を60に設定したことでそこまでのユーザーは対応している
ただし、デフォルトが60なため、この修正の原因であったユーザーの環境で改善されるかどうかは定かではない。